### PR TITLE
Fix exposed API key value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
     <artifactId>bigpanda-jenkins</artifactId>
     <description>Notifies BigPanda of Jenkins builds</description>
     <url>https://github.com/jenkinsci/bigpanda-plugin</url>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/bigpanda-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/bigpanda-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/bigpanda-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:ssh://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
     <licenses>
         <license>
@@ -85,6 +85,9 @@
         </dependency>
     </dependencies>
     <properties>
+        <revision>1.4.1</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/bigpanda-plugin</gitHubRepo>
         <jenkins.version>2.387</jenkins.version>
     </properties>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,16 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30</version>
+        <version>4.53</version>
         <relativePath />
     </parent>
     <name>BigPanda Notifier</name>
     <artifactId>bigpanda-jenkins</artifactId>
     <description>Notifies BigPanda of Jenkins builds</description>
     <url>https://github.com/jenkinsci/bigpanda-plugin</url>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/bigpanda-plugin.git</connection>
@@ -21,7 +21,7 @@
     <licenses>
         <license>
             <name>apache v2</name>
-            <url>http://opensource.org/licenses/Apache-2.0</url>
+            <url>https://opensource.org/licenses/Apache-2.0</url>
         </license>
     </licenses>
     <developers>
@@ -60,28 +60,32 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.5</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.12.1</version>
+            <version>5.0.0</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>command-launcher</artifactId>
-            <version>1.3</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.3</version>
+            <version>1166.va_436e268e972</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>839.v35e2736cfd5c</version>
         </dependency>
     </dependencies>
     <properties>
-        <jenkins.version>2.190.1</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.387</jenkins.version>
     </properties>
     <build>
         <plugins>
@@ -95,8 +99,8 @@
                     <force>true</force>
                     <failOnError>false</failOnError>
                     <links>
-                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
-                        <link>http://download.eclipse.org/jgit/site/${jgit.version}/org.eclipse.jgit/apidocs/</link>
+                        <link>https://docs.oracle.com/javase/11/docs/api/</link>
+                        <link>https://download.eclipse.org/jgit/site/${jgit.version}/org.eclipse.jgit/apidocs/</link>
                     </links>
                     <!-- <additionalOptions>-html5</additionalOptions> -->
                 </configuration>
@@ -104,6 +108,7 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
+                <version>3.38</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/src/main/java/org/jenkinsci/plugins/bigpanda/BigpandaGlobalNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/bigpanda/BigpandaGlobalNotifier.java
@@ -14,6 +14,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
@@ -51,7 +52,7 @@ public class BigpandaGlobalNotifier extends RunListener<Run<?, ?>> implements De
 
         change = changeBuilder.create();
 
-        BigpandaApiWrapper bpApi = new BigpandaApiWrapper( ((DescriptorImpl) descriptor).getBigpandaApiKey(), 
+        BigpandaApiWrapper bpApi = new BigpandaApiWrapper( ((DescriptorImpl) descriptor).getBigpandaApiKey().getPlainText(), 
                                                             ((DescriptorImpl) descriptor).getBigpandaAppKey(), ((DescriptorImpl) descriptor).getWebhookUrl());
 
         try {
@@ -65,7 +66,7 @@ public class BigpandaGlobalNotifier extends RunListener<Run<?, ?>> implements De
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<BigpandaGlobalNotifier> {
-        private String bigpandaApiKey;
+        private Secret bigpandaApiKey;
         private String bigpandaAppKey;
         private String webhookUrl;
         private static String defaultWebhookUrl = "https://inbound.bigpanda.io/jenkins/changes";
@@ -90,7 +91,7 @@ public class BigpandaGlobalNotifier extends RunListener<Run<?, ?>> implements De
         /**
          * @return Bigpanda Api Key
          */
-        public String getBigpandaApiKey() {
+        public Secret getBigpandaApiKey() {
             return this.bigpandaApiKey;
         }
 
@@ -122,7 +123,7 @@ public class BigpandaGlobalNotifier extends RunListener<Run<?, ?>> implements De
         }
 
         @DataBoundSetter
-        public void setBigpandaApiKey(String bigpandaApiKey) {
+        public void setBigpandaApiKey(Secret bigpandaApiKey) {
             this.bigpandaApiKey = bigpandaApiKey;
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/bigpanda/BigpandaGlobalNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bigpanda/BigpandaGlobalNotifier/global.jelly
@@ -6,7 +6,7 @@
       field="bigpandaApiKey"
       value="${descriptor.getBigPandaApiKey()}"
       help="${rootUrl}/plugin/bigpanda-jenkins/help-bigpanda-api.html">
-      <f:textbox />
+      <f:password />
     </f:entry>
     <f:entry title="BigPanda App Key"
       description="BigPanda Integration key"


### PR DESCRIPTION
- API key will now be concealed in the Jenkins UI and within the global xml config.
- Fixed pom.xml to support Java 11 or newer (For reference: https://www.jenkins.io/blog/2022/12/14/require-java-11/) 