### PR TITLE
BP-1747 set the plugin build plan to use Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,4 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin( configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
+])


### PR DESCRIPTION
Our plugin was set up to test on Java 8 before creating a new release. Jenkins is moving to fully requiring Java 11. We should build/test our plugin against 11 from now on and not 8 as the standard